### PR TITLE
ASM dependency was missing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
    <version>17.0</version>
   </dependency>
 
+  <dependency>
+   <groupId>org.ow2.asm</groupId>
+   <artifactId>asm-debug-all</artifactId>
+   <version>5.0</version>
+  </dependency>
+
   <!-- TEST DEPENDENCIES -->
   <dependency>
    <groupId>junit</groupId>


### PR DESCRIPTION
The ASM dependency was missing, I made sure to use the same ASM version as in blinky-core. This should solve #1.